### PR TITLE
Fix markov blanket

### DIFF
--- a/app/src/main/scala/scappla/app/TestFullTicTacToe.scala
+++ b/app/src/main/scala/scappla/app/TestFullTicTacToe.scala
@@ -1,0 +1,232 @@
+package scappla.app
+
+import scappla._
+import scappla.guides._
+import scappla.optimization._
+import scappla.tensor._
+import scappla.distributions._
+import scappla.Functions._
+
+object TestFullTicTacToe extends App {
+
+  sealed trait Tag {
+    def switch: Tag
+  }
+  case object Neither extends Tag {
+    lazy val switch = Neither
+  }
+  case object Cross extends Tag {
+    lazy val switch = Circle
+  }
+  case object Circle extends Tag {
+    lazy val switch = Cross
+  }
+
+  case class Board(private val tags: Array[Tag]) {
+
+    def play(x: Int, y: Int, tag: Tag): Board = {
+      val newtags = tags.clone
+      val idx = index(x, y)
+      if (tags(idx) != Neither) {
+        throw new RuntimeException("")
+      }
+      newtags(idx) = tag
+      this.copy(tags = newtags)
+    }
+
+    private def index(x: Int, y: Int) = 3 * y + x
+
+    def hasWon(tag: Tag): Boolean = {
+      def eq(x: Int, y: Int): Boolean =
+        tags(index(x, y)) == tag
+      ((0 until 3).exists { y =>
+        (0 until 3).forall(eq(_, y))
+      }) ||
+      ((0 until 3).exists { x =>
+        (0 until 3).forall(eq(x, _))
+      }) ||
+      (0 until 3).forall(x => eq(x, x)) ||
+      (0 until 3).forall(x => eq(x, 2 - x))
+    }
+
+    val isFull: Boolean = {
+      (0 until 3).forall { y =>
+        (0 until 3).forall { x =>
+          tags(index(x, y)) != Neither
+        }
+      }
+    }
+
+    def empty: Seq[(Int, Int)] = {
+      (for {
+        y <- 0 until 3
+        x <- 0 until 3
+      } yield {
+        tags(index(x, y)) match {
+          case Neither => Some((x, y))
+          case _       => None
+        }
+      }).flatten
+    }
+
+    def strLines: Seq[String] = {
+      for {
+        y <- 0 until 3
+      } yield {
+        (for { x <- 0 until 3 } yield {
+          tags(index(x, y)) match {
+            case Cross   => "x"
+            case Circle  => "o"
+            case Neither => "."
+          }
+        }).mkString(" ")
+      }
+    }
+
+    override def equals(other: Any): Boolean = {
+      other match {
+        case that: Board =>
+          this.tags.deep == that.tags.deep
+        case _ => false
+      }
+    }
+
+    override val hashCode: Int = {
+      this.tags.toSeq.hashCode
+    }
+  }
+
+  object Board {
+    def apply(): Board = Board(Array.fill(9)(Neither))
+  }
+
+  case class Player(tag: Tag) {
+    def other = Player(tag.switch)
+  }
+
+  import scappla.tensor._
+  import scappla.tensor.Tensor._
+  import scappla._
+  import scappla.distributions.{Categorical, Bernoulli}
+  import scappla.guides._
+  import scappla.Functions._
+
+  case class BoardDim(size: Int) extends Dim[BoardDim]
+
+  case class Guide(
+      prior_param: Expr[ArrayTensor, BoardDim],
+      posterior_param: Expr[ArrayTensor, BoardDim],
+      size: Int
+  ) {
+    // implicit val gridField = implicitly[TensorField[ArrayTensor, BoardDim]]
+    // val posterior = DiscreteGuide(Categorical(posterior_param), size)
+    val posterior = BBVIGuide(Categorical(posterior_param))
+    def prior = Categorical(prior_param)
+  }
+
+  object Guide {
+    private val guides: scala.collection.mutable.Map[Board, Guide] =
+      scala.collection.mutable.Map.empty
+
+    def reset: Unit = {
+      guides.clear()
+    }
+
+    def size: Int = guides.size
+
+    def apply(board: Board): Guide = {
+      if (!guides.contains(board)) {
+        guides(board) = newGuide(board)
+      }
+      guides(board)
+    }
+
+    private def newGuide(board: Board): Guide = {
+      val free = board.empty
+      // println(s"free: ${free}")
+      val boardDim = BoardDim(free.size)
+      val initial = ArrayTensor(boardDim.sizes, Array.fill(free.size)(0f))
+
+      val prior_param = ConstantExpr(exp(Constant(initial, boardDim)))
+      val posterior_param = exp(Param(initial, boardDim))
+      Guide(prior_param, posterior_param, free.size)
+    }
+  }
+
+  val startBoard = Board()
+    // .play(1, 1, Cross)
+    // .play(2, 1, Cross)
+    // .play(1, 0, Circle)
+    // .play(1, 2, Circle)
+  val startTag = Circle
+// val startTag = Cross
+
+  val model = infer {
+
+    def next(board: Board, player: Player): (Seq[(Int, Int)], Tag) = {
+      if (board.hasWon(Cross)) {
+        (Seq.empty, Cross)
+      } else if (board.hasWon(Circle)) {
+        (Seq.empty, Circle)
+      } else if (board.isFull) {
+        (Seq.empty, Neither)
+      } else {
+        val guide = Guide(board)
+        val options = board.empty
+        val pos = sample(guide.prior, guide.posterior)
+        val (x, y) = options(pos)
+        val (sequence, winner) =
+          next(board.play(x, y, player.tag), player.other)
+        if (winner == Neither) {
+          observe(Bernoulli(0.9), false)
+        } else if (winner != player.tag) {
+          observe(Bernoulli(0.99), false)
+        }
+        ((x, y) +: sequence, winner)
+      }
+    }
+    next(startBoard, Player(startTag))
+  }
+
+  import scappla.optimization._
+
+  val board = Board()
+  val optimizer = new Adam(0.01)
+  val interpreter = new scappla.OptimizingInterpreter(optimizer)
+  Guide.reset
+  var wins = Map.empty[Tag, Int].withDefaultValue(0)
+  var sequences = Map.empty[Seq[Tuple2[Int, Int]], Int].withDefaultValue(0)
+  // for { iter <- 1 until 1000001 } {
+  var iter = 0
+  while (true) {
+    interpreter.reset()
+    val (sequence: Seq[Tuple2[Int, Int]], winner) = model.sample(interpreter)
+    wins = wins + (winner -> (wins(winner) + 1))
+    sequences = sequences + (sequence -> (sequences(sequence) + 1))
+    if (iter % 10000 == 0) {
+      println(
+        s"X: ${wins(Cross) / iter.toFloat}, O: ${wins(Circle) / iter.toFloat}, -: ${wins(Neither) / iter.toFloat}"
+      )
+      println(s"$winner (${Guide.size} guides)")
+
+      // sequence.head
+      val boards = (for {
+        (topSequence, _) <- sequences.toSeq.sortBy(-_._2).take(10)
+      } yield {
+        val (lastBoard, _) = topSequence.foldLeft((startBoard, startTag: Tag)) {
+          case ((b, tag), (x, y)) => (b.play(x, y, tag), tag.switch)
+        }
+        lastBoard
+      })
+      (for { y <- 0 until 3 } yield {
+        (for { board <- boards } yield {
+          board.strLines(y)
+        }).mkString("   ")
+      }).foreach(println _)
+
+      // lastBoard.strLines.foreach(println _)
+    }
+    iter += 1
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -43,11 +43,12 @@ lazy val app = (project in file("app")).settings(
   moduleName := "infer-app",
   // mainClass in Compile := Some("scappla.app.TestChickweight"),
   // mainClass in Compile := Some("scappla.app.TestMixture"),
-  mainClass in Compile := Some("scappla.app.TestTicTacToe"),
+  mainClass in Compile := Some("scappla.app.TestFullTicTacToe"),
+  // mainClass in Compile := Some("scappla.app.TestTicTacToe"),
   libraryDependencies ++= Seq(
     "com.github.tototoshi"       %% "scala-csv"          % "1.3.5"
   ),
-  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full) //,
-//  scalacOptions ++= Seq("-Ymacro-debug-lite", "-Xlog-implicits")
+  // scalacOptions ++= Seq("-Ymacro-debug-lite", "-Xlog-implicits"),
+  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 ) dependsOn core
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 name := "scala-infer-parent"
 
 ThisBuild / organization := "scala-infer"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.10"
 ThisBuild / skip in publish := true
 ThisBuild / useCoursier := false
 

--- a/core/src/main/scala/scappla/distributions/Categorical.scala
+++ b/core/src/main/scala/scappla/distributions/Categorical.scala
@@ -16,7 +16,13 @@ case class Categorical[S <: Dim[_], D: TensorData](pExpr: Expr[D, S]) extends Di
     val totalv = interpreter.eval(total)
     val draw = Random.nextDouble() * totalv.v
     val cs = cumsum(p, p.shape)
-    count(cs, GreaterThan(draw.toFloat))
+    val index = p.shape.size - count(cs, GreaterThan(draw.toFloat))
+    if (index == p.shape.size) {
+      // rounding error - should occur only very rarely
+      p.shape.size - 1
+    } else {
+      index
+    }
   }
 
   override def observe(interpreter: Interpreter, index: Int): Score = {

--- a/core/src/test/scala/scappla/optimization/BlockLBFGSTest.scala
+++ b/core/src/test/scala/scappla/optimization/BlockLBFGSTest.scala
@@ -42,7 +42,7 @@ class BlockLBFGSTest extends FlatSpec {
       for {iter <- 0 until N} {
         val xBuf = xParam.buffer
         val yBuf = yParam.buffer
-        println(s"x: ${xBuf.v}, y: ${yBuf.v} (iter $iter)")
+        // println(s"x: ${xBuf.v}, y: ${yBuf.v} (iter $iter)")
         val value = f(xBuf, yBuf)
         value.dv(1.0)
         xBuf.complete()


### PR DESCRIPTION
Each variable on the stack should receive an observation only once.  By immediately passing the log-probability immediately onto argument variables, they could receive it multiple times.

With this fix in place, it is now possible to learn tic-tac-toe from scratch by playing games.  I.e. each player learns the optimal move for each board configuration.  (resulting eventually in all games being draws)